### PR TITLE
Support packages with only one version

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ const getVersionsForPackage = async package => {
   }
   const { stdout } = await exec("npm view " + packageName + " versions");
 
+  // packages with only one version return string with version number
+  if (stdout[0] != '[') {
+    return [packageName + "@" + stdout.replace(/\n/g, '')];
+  }
   return JSON.parse(stdout.replace(/'/g, '"'))
     .filter(
       version =>


### PR DESCRIPTION
Packages with only one version will return a flat string rather than an array via `npm view`, so this supports that

Associated error may look like this:
```
Fetching information for 31 packages...
 ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 10% | ETA: 30s | 3/31undefined:1
10.2.0
    ^

SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
    at JSON.parse (<anonymous>)
    at getVersionsForPackage (/opt/homebrew/lib/node_modules/pkgmigr8or/index.js:56:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /opt/homebrew/lib/node_modules/pkgmigr8or/index.js:25:15
    at async /opt/homebrew/lib/node_modules/pkgmigr8or/index.js:35:24
    at async Promise.all (index 9)
    at async /opt/homebrew/lib/node_modules/pkgmigr8or/index.js:77:31
```

Cheers!